### PR TITLE
Add DCF button to site navigation

### DIFF
--- a/about.html
+++ b/about.html
@@ -16,6 +16,7 @@
         <a href="index.html" class="text-gray-700 hover:text-blue-600">Home</a>
         <a href="features.html" class="text-gray-700 hover:text-blue-600">Features</a>
         <a href="prompt.html" class="text-gray-700 hover:text-blue-600">How-To</a>
+        <a href="analyze.html" class="text-gray-700 hover:text-blue-600">DCF</a>
         <a href="efficient-frontier.html" class="text-blue-600 font-medium">Efficient Frontier</a>
         <a href="about.html" class="text-blue-600 font-medium">About</a>
         <a href="faq.html" class="text-blue-600 font-medium">FAQ</a>

--- a/efficient-frontier.html
+++ b/efficient-frontier.html
@@ -19,6 +19,7 @@
         <a href="index.html" class="text-gray-700 hover:text-blue-600">Home</a>
         <a href="features.html" class="text-gray-700 hover:text-blue-600">Features</a>
         <a href="prompt.html" class="text-gray-700 hover:text-blue-600">How-To</a>
+        <a href="analyze.html" class="text-gray-700 hover:text-blue-600">DCF</a>
         <a href="efficient-frontier.html" class="text-blue-600 font-medium">Efficient Frontier</a>
         <a href="about.html" class="text-blue-600 font-medium">About</a>
         <a href="faq.html" class="text-blue-600 font-medium">FAQ</a>

--- a/faq.html
+++ b/faq.html
@@ -16,6 +16,7 @@
          <a href="index.html" class="text-gray-700 hover:text-blue-600">Home</a>
         <a href="features.html" class="text-gray-700 hover:text-blue-600">Features</a>
         <a href="prompt.html" class="text-gray-700 hover:text-blue-600">How-To</a>
+        <a href="analyze.html" class="text-gray-700 hover:text-blue-600">DCF</a>
         <a href="efficient-frontier.html" class="text-blue-600 font-medium">Efficient Frontier</a>
         <a href="about.html" class="text-blue-600 font-medium">About</a>
         <a href="faq.html" class="text-blue-600 font-medium">FAQ</a>

--- a/features.html
+++ b/features.html
@@ -16,6 +16,7 @@
         <a href="index.html" class="text-gray-700 hover:text-blue-600">Home</a>
         <a href="features.html" class="text-gray-700 hover:text-blue-600">Features</a>
         <a href="prompt.html" class="text-gray-700 hover:text-blue-600">How-To</a>
+        <a href="analyze.html" class="text-gray-700 hover:text-blue-600">DCF</a>
         <a href="efficient-frontier.html" class="text-blue-600 font-medium">Efficient Frontier</a>
         <a href="about.html" class="text-blue-600 font-medium">About</a>
         <a href="faq.html" class="text-blue-600 font-medium">FAQ</a>

--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
         <a href="index.html" class="text-gray-700 hover:text-blue-600">Home</a>
         <a href="features.html" class="text-gray-700 hover:text-blue-600">Features</a>
         <a href="prompt.html" class="text-gray-700 hover:text-blue-600">How-To</a>
+        <a href="analyze.html" class="text-gray-700 hover:text-blue-600">DCF</a>
         <a href="efficient-frontier.html" class="text-blue-600 font-medium">Efficient Frontier</a>
         <a href="about.html" class="text-blue-600 font-medium">About</a>
         <a href="faq.html" class="text-blue-600 font-medium">FAQ</a>

--- a/prompt.html
+++ b/prompt.html
@@ -16,6 +16,7 @@
          <a href="index.html" class="text-gray-700 hover:text-blue-600">Home</a>
         <a href="features.html" class="text-gray-700 hover:text-blue-600">Features</a>
         <a href="prompt.html" class="text-gray-700 hover:text-blue-600">How-To</a>
+        <a href="analyze.html" class="text-gray-700 hover:text-blue-600">DCF</a>
         <a href="efficient-frontier.html" class="text-blue-600 font-medium">Efficient Frontier</a>
         <a href="about.html" class="text-blue-600 font-medium">About</a>
         <a href="faq.html" class="text-blue-600 font-medium">FAQ</a>


### PR DESCRIPTION
## Summary
- Add a "DCF" button linking to analyze.html in the navigation header of all HTML pages.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4b00646e88326aabe2c86bd4b5d8e