### PR TITLE
Add dark mode and gradient header to modernize site

### DIFF
--- a/about.html
+++ b/about.html
@@ -4,22 +4,26 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>About - AI-Powered Investment Tools</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <script>tailwind.config = { darkMode: 'class' }</script>
   <script src="https://cdn.tailwindcss.com"></script>
+  <style>body{font-family:'Inter',sans-serif}</style>
 </head>
-<body class="bg-gray-50 text-gray-800 min-h-screen flex flex-col items-center">
+<body class="bg-gray-50 text-gray-800 dark:bg-gray-900 dark:text-gray-100 min-h-screen flex flex-col items-center">
 
   <!-- Header -->
-  <header class="fixed top-0 w-full bg-white shadow-sm z-10">
+  <header class="fixed top-0 w-full bg-gradient-to-r from-blue-500 to-indigo-600 dark:from-gray-800 dark:to-gray-900 text-white shadow-md z-10">
     <div class="max-w-4xl mx-auto flex items-center justify-between p-4">
       <div class="text-xl font-semibold">AI-Invest</div>
-      <nav class="space-x-4">
-        <a href="index.html" class="text-gray-700 hover:text-blue-600">Home</a>
-        <a href="features.html" class="text-gray-700 hover:text-blue-600">Features</a>
-        <a href="prompt.html" class="text-gray-700 hover:text-blue-600">How-To</a>
-        <a href="efficient-frontier.html" class="text-blue-600 font-medium">Efficient Frontier</a>
-        <a href="dcf.html" class="text-blue-600 font-medium">DCF</a>
-        <a href="about.html" class="text-blue-600 font-medium">About</a>
-        <a href="faq.html" class="text-blue-600 font-medium">FAQ</a>
+      <nav class="flex items-center space-x-4">
+        <a href="index.html" class="text-white/80 hover:text-white">Home</a>
+        <a href="features.html" class="text-white/80 hover:text-white">Features</a>
+        <a href="prompt.html" class="text-white/80 hover:text-white">How-To</a>
+        <a href="efficient-frontier.html" class="text-white/80 hover:text-white">Efficient Frontier</a>
+        <a href="dcf.html" class="text-white/80 hover:text-white">DCF</a>
+        <a href="about.html" class="text-white/80 hover:text-white">About</a>
+        <a href="faq.html" class="text-white/80 hover:text-white">FAQ</a>
+        <button id="theme-toggle" class="ml-4 p-2 rounded bg-white/10 hover:bg-white/20 transition-colors"><span id="theme-icon">🌙</span></button>
       </nav>
     </div>
   </header>
@@ -27,7 +31,7 @@
   <main class="pt-20 w-full max-w-4xl space-y-6 p-4">
     <h1 class="text-2xl font-bold text-center">About AI-Invest</h1>
 
-    <section class="bg-white p-6 rounded-lg shadow-sm">
+    <section class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-sm">
       <h2 class="text-xl font-semibold mb-2">Mission</h2>
       <p class="text-sm">
         To serve as a hands-on educational resource, empowering investors of all levels to harness ChatGPT’s capabilities in their
@@ -37,7 +41,7 @@
     </section>
 
     <!-- Recommended Resources -->
-    <section class="bg-white p-6 rounded-lg shadow-sm">
+    <section class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-sm">
       <h2 class="text-xl font-semibold mb-2">Recommended Resources</h2>
       <ul class="list-disc list-inside text-sm space-y-2">
         <li>
@@ -58,10 +62,12 @@
   </main>
 
   <!-- Disclaimer Only -->
-  <footer class="mt-auto w-full bg-white p-4 text-center text-sm text-gray-600">
+  <footer class="mt-auto w-full bg-white dark:bg-gray-800 p-4 text-center text-sm text-gray-600 dark:text-gray-400">
     <p class="font-semibold">Disclosure:</p>
     <p>This is not investment advice; educational purpose only. I may earn a commission if you subscribe—at no extra cost to you.</p>
   </footer>
+
+  <script src="theme.js"></script>
 
 </body>
 </html>

--- a/analyze.html
+++ b/analyze.html
@@ -4,14 +4,35 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Live Ticker Analysis</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <script>tailwind.config = { darkMode: 'class' }</script>
   <script src="https://cdn.tailwindcss.com"></script>
+  <style>body{font-family:'Inter',sans-serif}</style>
   <!-- Google AdSense -->
   <script async
           src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7032908618576389"
           crossorigin="anonymous"></script>
 </head>
-<body class="bg-gray-50 text-gray-800 flex flex-col items-center p-4">
+<body class="bg-gray-50 text-gray-800 dark:bg-gray-900 dark:text-gray-100 min-h-screen flex flex-col items-center">
 
+  <!-- Header -->
+  <header class="fixed top-0 w-full bg-gradient-to-r from-blue-500 to-indigo-600 dark:from-gray-800 dark:to-gray-900 text-white shadow-md z-10">
+    <div class="max-w-4xl mx-auto flex items-center justify-between p-4">
+      <div class="text-xl font-semibold">AI-Invest</div>
+      <nav class="flex items-center space-x-4">
+        <a href="index.html" class="text-white/80 hover:text-white">Home</a>
+        <a href="features.html" class="text-white/80 hover:text-white">Features</a>
+        <a href="prompt.html" class="text-white/80 hover:text-white">How-To</a>
+        <a href="efficient-frontier.html" class="text-white/80 hover:text-white">Efficient Frontier</a>
+        <a href="dcf.html" class="text-white/80 hover:text-white">DCF</a>
+        <a href="about.html" class="text-white/80 hover:text-white">About</a>
+        <a href="faq.html" class="text-white/80 hover:text-white">FAQ</a>
+        <button id="theme-toggle" class="ml-4 p-2 rounded bg-white/10 hover:bg-white/20 transition-colors"><span id="theme-icon">🌙</span></button>
+      </nav>
+    </div>
+  </header>
+
+  <main class="pt-24 w-full max-w-4xl flex flex-col items-center p-4">
   <h1 class="text-2xl font-bold mb-4">Live Ticker Analysis</h1>
 
   <form id="analysis-form" class="flex flex-col items-center gap-2 w-full max-w-md">
@@ -28,7 +49,7 @@
     >Analyze</button>
   </form>
 
-  <div id="result" class="mt-6 w-full max-w-md bg-white p-4 rounded shadow-sm whitespace-pre-wrap"></div>
+  <div id="result" class="mt-6 w-full max-w-md bg-white dark:bg-gray-800 p-4 rounded shadow-sm whitespace-pre-wrap"></div>
 
   <script>
     const form = document.getElementById('analysis-form');
@@ -70,6 +91,7 @@
     });
   </script>
 
+  <script src="theme.js"></script>
 </body>
 </html>
 

--- a/dcf.html
+++ b/dcf.html
@@ -6,29 +6,33 @@
   <title></title>
   <!-- Favicon uses the same icon as the rest of the site -->
   <link rel="icon" href="icon.png">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <script>tailwind.config = { darkMode: 'class' }</script>
   <!-- Include Tailwind CSS from CDN to mirror the existing site styling -->
   <script src="https://cdn.tailwindcss.com"></script>
+  <style>body{font-family:'Inter',sans-serif}</style>
 </head>
-<body class="bg-gray-50 text-gray-800 min-h-screen flex flex-col items-center">
+<body class="bg-gray-50 text-gray-800 dark:bg-gray-900 dark:text-gray-100 min-h-screen flex flex-col items-center">
   <!-- Header -->
-  <header class="fixed top-0 w-full bg-white shadow-sm z-10">
+  <header class="fixed top-0 w-full bg-gradient-to-r from-blue-500 to-indigo-600 dark:from-gray-800 dark:to-gray-900 text-white shadow-md z-10">
     <div class="max-w-4xl mx-auto flex items-center justify-between p-4">
       <div class="text-xl font-semibold">AI‑Invest</div>
-      <nav class="space-x-4">
+      <nav class="flex items-center space-x-4">
         <!-- Keep the existing navigation links -->
-        <a href="index.html" class="text-gray-700 hover:text-blue-600">Home</a>
-        <a href="features.html" class="text-gray-700 hover:text-blue-600">Features</a>
-        <a href="prompt.html" class="text-gray-700 hover:text-blue-600">How-To</a>
-        <a href="efficient-frontier.html" class="text-blue-600 font-medium">Efficient Frontier</a>
-        <a href="dcf.html" class="text-blue-600 font-medium">DCF</a>
-        <a href="about.html" class="text-blue-600 font-medium">About</a>
-        <a href="faq.html" class="text-blue-600 font-medium">FAQ</a>
+        <a href="index.html" class="text-white/80 hover:text-white">Home</a>
+        <a href="features.html" class="text-white/80 hover:text-white">Features</a>
+        <a href="prompt.html" class="text-white/80 hover:text-white">How-To</a>
+        <a href="efficient-frontier.html" class="text-white/80 hover:text-white">Efficient Frontier</a>
+        <a href="dcf.html" class="text-white/80 hover:text-white">DCF</a>
+        <a href="about.html" class="text-white/80 hover:text-white">About</a>
+        <a href="faq.html" class="text-white/80 hover:text-white">FAQ</a>
+        <button id="theme-toggle" class="ml-4 p-2 rounded bg-white/10 hover:bg-white/20 transition-colors"><span id="theme-icon">🌙</span></button>
       </nav>
     </div>
   </header>
 
   <!-- Main content -->
-  <main class="pt-55 w-full max-w-4xl flex flex-col items-center gap-2 p-4">
+  <main class="pt-24 w-full max-w-4xl flex flex-col items-center gap-2 p-4">
     <h1 class="text-2xl font-bold text-center text-gray-800">Discounted Cash Flow</h1>
     <p class="text-center text-gray-600"></p>
     <!-- Container for iframe. Use a responsive height for the embedded app -->
@@ -42,10 +46,11 @@
   </main>
 
   <!-- Footer -->
-  <footer class="mt-auto w-full bg-white p-4 text-center text-sm text-gray-600">
+  <footer class="mt-auto w-full bg-white dark:bg-gray-800 p-4 text-center text-sm text-gray-600 dark:text-gray-400">
     <p>Get more stock data here — <a href="https://stockanalysis.com/pro/?ref=daniel" target="_blank" class="text-blue-600 hover:underline">Stock Analysis Pro</a></p>
     <p class="mt-2 font-semibold">Disclosure:</p>
     <p>This is not investment advice; educational purpose only. I may earn a commission if you subscribe—at no extra cost to you.</p>
   </footer>
+  <script src="theme.js"></script>
 </body>
 </html>

--- a/efficient-frontier.html
+++ b/efficient-frontier.html
@@ -6,29 +6,33 @@
   <title></title>
   <!-- Favicon uses the same icon as the rest of the site -->
   <link rel="icon" href="icon.png">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <script>tailwind.config = { darkMode: 'class' }</script>
   <!-- Include Tailwind CSS from CDN to mirror the existing site styling -->
   <script src="https://cdn.tailwindcss.com"></script>
+  <style>body{font-family:'Inter',sans-serif}</style>
 </head>
-<body class="bg-gray-50 text-gray-800 min-h-screen flex flex-col items-center">
+<body class="bg-gray-50 text-gray-800 dark:bg-gray-900 dark:text-gray-100 min-h-screen flex flex-col items-center">
   <!-- Header -->
-  <header class="fixed top-0 w-full bg-white shadow-sm z-10">
+  <header class="fixed top-0 w-full bg-gradient-to-r from-blue-500 to-indigo-600 dark:from-gray-800 dark:to-gray-900 text-white shadow-md z-10">
     <div class="max-w-4xl mx-auto flex items-center justify-between p-4">
       <div class="text-xl font-semibold">AI‑Invest</div>
-      <nav class="space-x-4">
+      <nav class="flex items-center space-x-4">
         <!-- Keep the existing navigation links -->
-        <a href="index.html" class="text-gray-700 hover:text-blue-600">Home</a>
-        <a href="features.html" class="text-gray-700 hover:text-blue-600">Features</a>
-        <a href="prompt.html" class="text-gray-700 hover:text-blue-600">How-To</a>
-        <a href="efficient-frontier.html" class="text-blue-600 font-medium">Efficient Frontier</a>
-        <a href="dcf.html" class="text-blue-600 font-medium">DCF</a>
-        <a href="about.html" class="text-blue-600 font-medium">About</a>
-        <a href="faq.html" class="text-blue-600 font-medium">FAQ</a>
+        <a href="index.html" class="text-white/80 hover:text-white">Home</a>
+        <a href="features.html" class="text-white/80 hover:text-white">Features</a>
+        <a href="prompt.html" class="text-white/80 hover:text-white">How-To</a>
+        <a href="efficient-frontier.html" class="text-white/80 hover:text-white">Efficient Frontier</a>
+        <a href="dcf.html" class="text-white/80 hover:text-white">DCF</a>
+        <a href="about.html" class="text-white/80 hover:text-white">About</a>
+        <a href="faq.html" class="text-white/80 hover:text-white">FAQ</a>
+        <button id="theme-toggle" class="ml-4 p-2 rounded bg-white/10 hover:bg-white/20 transition-colors"><span id="theme-icon">🌙</span></button>
       </nav>
     </div>
   </header>
 
   <!-- Main content -->
-  <main class="pt-55 w-full max-w-4xl flex flex-col items-center gap-2 p-4">
+  <main class="pt-24 w-full max-w-4xl flex flex-col items-center gap-2 p-4">
     <h1 class="text-2xl font-bold text-center text-gray-800">Efficient Frontier Explorer</h1>
     <p class="text-center text-gray-600"></p>
     <!-- Container for iframe. Use a responsive height for the embedded app -->
@@ -42,10 +46,11 @@
   </main>
 
   <!-- Footer -->
-  <footer class="mt-auto w-full bg-white p-4 text-center text-sm text-gray-600">
+  <footer class="mt-auto w-full bg-white dark:bg-gray-800 p-4 text-center text-sm text-gray-600 dark:text-gray-400">
     <p>Get more stock data here — <a href="https://stockanalysis.com/pro/?ref=daniel" target="_blank" class="text-blue-600 hover:underline">Stock Analysis Pro</a></p>
     <p class="mt-2 font-semibold">Disclosure:</p>
     <p>This is not investment advice; educational purpose only. I may earn a commission if you subscribe—at no extra cost to you.</p>
   </footer>
+  <script src="theme.js"></script>
 </body>
 </html>

--- a/faq.html
+++ b/faq.html
@@ -4,21 +4,26 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>FAQ - AI-Invest</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <script>tailwind.config = { darkMode: 'class' }</script>
   <script src="https://cdn.tailwindcss.com"></script>
+  <style>body{font-family:'Inter',sans-serif}</style>
 </head>
-<body class="bg-gray-50 text-gray-800 min-h-screen flex flex-col items-center">
+<body class="bg-gray-50 text-gray-800 dark:bg-gray-900 dark:text-gray-100 min-h-screen flex flex-col items-center">
 
   <!-- Header -->
-  <header class="fixed top-0 w-full bg-white shadow-sm z-10">
+  <header class="fixed top-0 w-full bg-gradient-to-r from-blue-500 to-indigo-600 dark:from-gray-800 dark:to-gray-900 text-white shadow-md z-10">
     <div class="max-w-4xl mx-auto flex items-center justify-between p-4">
       <div class="text-xl font-semibold">AI-Invest</div>
-      <nav class="space-x-4">
-         <a href="index.html" class="text-gray-700 hover:text-blue-600">Home</a>
-        <a href="features.html" class="text-gray-700 hover:text-blue-600">Features</a>
-        <a href="prompt.html" class="text-gray-700 hover:text-blue-600">How-To</a>
-        <a href="efficient-frontier.html" class="text-blue-600 font-medium">Efficient Frontier</a>
-        <a href="about.html" class="text-blue-600 font-medium">About</a>
-        <a href="faq.html" class="text-blue-600 font-medium">FAQ</a>
+      <nav class="flex items-center space-x-4">
+         <a href="index.html" class="text-white/80 hover:text-white">Home</a>
+        <a href="features.html" class="text-white/80 hover:text-white">Features</a>
+        <a href="prompt.html" class="text-white/80 hover:text-white">How-To</a>
+        <a href="efficient-frontier.html" class="text-white/80 hover:text-white">Efficient Frontier</a>
+        <a href="dcf.html" class="text-white/80 hover:text-white">DCF</a>
+        <a href="about.html" class="text-white/80 hover:text-white">About</a>
+        <a href="faq.html" class="text-white/80 hover:text-white">FAQ</a>
+        <button id="theme-toggle" class="ml-4 p-2 rounded bg-white/10 hover:bg-white/20 transition-colors"><span id="theme-icon">🌙</span></button>
       </nav>
     </div>
   </header>
@@ -27,7 +32,7 @@
     <h1 class="text-2xl font-bold text-center">Frequently Asked Questions</h1>
 
     <!-- General Section -->
-    <section class="bg-white p-6 rounded-lg shadow-sm">
+    <section class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-sm">
       <h2 class="text-xl font-semibold mb-2">General</h2>
       <ul class="list-disc list-inside text-sm space-y-2">
         <li><strong>What is AI-Invest?</strong> An educational platform that leverages GPT for financial analysis, modeling, and insights.</li>
@@ -37,7 +42,7 @@
     </section>
 
     <!-- Tool Usage Section -->
-    <section class="bg-white p-6 rounded-lg shadow-sm">
+    <section class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-sm">
       <h2 class="text-xl font-semibold mb-2">Using the Tools</h2>
       <ul class="list-disc list-inside text-sm space-y-2">
         <li><strong>Do I need to install anything?</strong> No. Everything works in-browser using GPT APIs.</li>
@@ -47,7 +52,7 @@
     </section>
 
     <!-- Hallucinations Section -->
-    <section class="bg-white p-6 rounded-lg shadow-sm">
+    <section class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-sm">
       <h2 class="text-xl font-semibold mb-4">What if GPT gives wrong or hallucinated answers?</h2>
       <p class="text-sm mb-4">GPT models may occasionally generate false or inaccurate information. Below is one real example of a hallucinated answer from an AI session, shown using two screenshots for context:</p>
       <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -63,7 +68,7 @@
     </section>
 
     <!-- Privacy Section -->
-    <section class="bg-white p-6 rounded-lg shadow-sm">
+    <section class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-sm">
       <h2 class="text-xl font-semibold mb-2">Privacy & Security</h2>
       <ul class="list-disc list-inside text-sm space-y-2">
         <li><strong>Do you store my data?</strong> No personal data is stored. Uploaded files are processed temporarily and discarded.</li>
@@ -73,10 +78,12 @@
   </main>
 
   <!-- Footer -->
-  <footer class="mt-auto w-full bg-white p-4 text-center text-sm text-gray-600">
+  <footer class="mt-auto w-full bg-white dark:bg-gray-800 p-4 text-center text-sm text-gray-600 dark:text-gray-400">
     <p class="font-semibold">Disclosure:</p>
     <p>This is not investment advice; educational purpose only. I may earn a commission if you subscribe—at no extra cost to you.</p>
   </footer>
+
+  <script src="theme.js"></script>
 
 </body>
 </html>

--- a/features.html
+++ b/features.html
@@ -4,21 +4,26 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Features - AI-Powered Investment Tools</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <script>tailwind.config = { darkMode: 'class' }</script>
   <script src="https://cdn.tailwindcss.com"></script>
+  <style>body{font-family:'Inter',sans-serif}</style>
 </head>
-<body class="bg-gray-50 text-gray-800 min-h-screen flex flex-col items-center">
+<body class="bg-gray-50 text-gray-800 dark:bg-gray-900 dark:text-gray-100 min-h-screen flex flex-col items-center">
 
   <!-- Header -->
-  <header class="fixed top-0 w-full bg-white shadow-sm z-10">
+  <header class="fixed top-0 w-full bg-gradient-to-r from-blue-500 to-indigo-600 dark:from-gray-800 dark:to-gray-900 text-white shadow-md z-10">
     <div class="max-w-4xl mx-auto flex items-center justify-between p-4">
       <div class="text-xl font-semibold">AI-Invest</div>
-      <nav class="space-x-4">
-        <a href="index.html" class="text-gray-700 hover:text-blue-600">Home</a>
-        <a href="features.html" class="text-gray-700 hover:text-blue-600">Features</a>
-        <a href="prompt.html" class="text-gray-700 hover:text-blue-600">How-To</a>
-        <a href="efficient-frontier.html" class="text-blue-600 font-medium">Efficient Frontier</a>
-        <a href="about.html" class="text-blue-600 font-medium">About</a>
-        <a href="faq.html" class="text-blue-600 font-medium">FAQ</a>
+      <nav class="flex items-center space-x-4">
+        <a href="index.html" class="text-white/80 hover:text-white">Home</a>
+        <a href="features.html" class="text-white/80 hover:text-white">Features</a>
+        <a href="prompt.html" class="text-white/80 hover:text-white">How-To</a>
+        <a href="efficient-frontier.html" class="text-white/80 hover:text-white">Efficient Frontier</a>
+        <a href="dcf.html" class="text-white/80 hover:text-white">DCF</a>
+        <a href="about.html" class="text-white/80 hover:text-white">About</a>
+        <a href="faq.html" class="text-white/80 hover:text-white">FAQ</a>
+        <button id="theme-toggle" class="ml-4 p-2 rounded bg-white/10 hover:bg-white/20 transition-colors"><span id="theme-icon">🌙</span></button>
       </nav>
     </div>
   </header>
@@ -27,7 +32,7 @@
     <h1 id="tool-details" class="text-2xl font-bold text-center mb-4">Tool Details &amp; Capabilities</h1>
 
     <!-- ETF Comparator -->
-    <section id="index-etf" class="bg-white p-6 rounded-lg shadow-sm">
+    <section id="index-etf" class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-sm">
       <h2 class="text-xl font-semibold mb-2">ETF Comparator</h2>
       <p class="mb-2 text-sm">Compare ETFs side by side on performance, sector exposure, fees, and risk metrics.</p>
       <ul class="list-disc list-inside text-sm space-y-1 mb-4">
@@ -39,7 +44,7 @@
     </section>
 
     <!-- Financial Sentiment Analyst -->
-    <section id="index-sentiment" class="bg-white p-6 rounded-lg shadow-sm">
+    <section id="index-sentiment" class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-sm">
       <h2 class="text-xl font-semibold mb-2">Financial Sentiment Analyst</h2>
       <p class="mb-2 text-sm">Analyze sentiment from news and social media for stocks and funds.</p>
       <ul class="list-disc list-inside text-sm space-y-1 mb-4">
@@ -51,7 +56,7 @@
     </section>
 
     <!-- Investment SWOT Strategist -->
-    <section id="index-swot" class="bg-white p-6 rounded-lg shadow-sm">
+    <section id="index-swot" class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-sm">
       <h2 class="text-xl font-semibold mb-2">Investment SWOT Strategist</h2>
       <p class="mb-2 text-sm">Generate SWOT analyses for stocks, sectors, or portfolios.</p>
       <ul class="list-disc list-inside text-sm space-y-1 mb-4">
@@ -63,7 +68,7 @@
     </section>
 
     <!-- Portfolio Optimizer Pro -->
-    <section id="index-optimizer" class="bg-white p-6 rounded-lg shadow-sm">
+    <section id="index-optimizer" class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-sm">
       <h2 class="text-xl font-semibold mb-2">Portfolio Optimizer Pro</h2>
       <p class="mb-2 text-sm">Optimize asset allocations using Modern Portfolio Theory and custom constraints.</p>
       <ul class="list-disc list-inside text-sm space-y-1 mb-4">
@@ -75,7 +80,7 @@
     </section>
 
     <!-- Portfolio Analysis Assistant -->
-    <section id="index-portfolio-analysis" class="bg-white p-6 rounded-lg shadow-sm">
+    <section id="index-portfolio-analysis" class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-sm">
       <h2 class="text-xl font-semibold mb-2">Portfolio Analysis Assistant</h2>
       <p class="mb-2 text-sm">Deep-dive into portfolio performance, asset allocation, and risk-return metrics.</p>
       <ul class="list-disc list-inside text-sm space-y-1 mb-4">
@@ -89,11 +94,13 @@
   </main>
 
   <!-- Affiliate + Disclaimer -->
-  <footer class="mt-auto w-full bg-white p-4 text-center text-sm text-gray-600">
+  <footer class="mt-auto w-full bg-white dark:bg-gray-800 p-4 text-center text-sm text-gray-600 dark:text-gray-400">
     <p>Get more stock data here — <a href="https://stockanalysis.com/pro/?ref=daniel" target="_blank" class="text-blue-600 hover:underline">Stock Analysis Pro</a></p>
     <p class="mt-2 font-semibold">Disclosure:</p>
     <p>This is not investment advice; educational purpose only. I may earn a commission if you subscribe—at no extra cost to you.</p>
   </footer>
+
+  <script src="theme.js"></script>
 
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -7,22 +7,26 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>AI-Powered Investment Tools</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <script>tailwind.config = { darkMode: 'class' }</script>
   <script src="https://cdn.tailwindcss.com"></script>
+  <style>body{font-family:'Inter',sans-serif}</style>
 </head>
-<body class="bg-gray-50 text-gray-800 min-h-screen flex flex-col items-center">
+<body class="bg-gray-50 text-gray-800 dark:bg-gray-900 dark:text-gray-100 min-h-screen flex flex-col items-center">
 
   <!-- Header -->
-  <header class="fixed top-0 w-full bg-white shadow-sm z-10">
+  <header class="fixed top-0 w-full bg-gradient-to-r from-blue-500 to-indigo-600 dark:from-gray-800 dark:to-gray-900 text-white shadow-md z-10">
     <div class="max-w-4xl mx-auto flex items-center justify-between p-4">
       <div class="text-xl font-semibold">AI-Invest</div>
-      <nav class="space-x-4">
-        <a href="index.html" class="text-gray-700 hover:text-blue-600">Home</a>
-        <a href="features.html" class="text-gray-700 hover:text-blue-600">Features</a>
-        <a href="prompt.html" class="text-gray-700 hover:text-blue-600">How-To</a>
-        <a href="efficient-frontier.html" class="text-blue-600 font-medium">Efficient Frontier</a>
-        <a href="dcf.html" class="text-blue-600 font-medium">DCF</a>
-        <a href="about.html" class="text-blue-600 font-medium">About</a>
-        <a href="faq.html" class="text-blue-600 font-medium">FAQ</a>
+      <nav class="flex items-center space-x-4">
+        <a href="index.html" class="text-white/80 hover:text-white">Home</a>
+        <a href="features.html" class="text-white/80 hover:text-white">Features</a>
+        <a href="prompt.html" class="text-white/80 hover:text-white">How-To</a>
+        <a href="efficient-frontier.html" class="text-white/80 hover:text-white">Efficient Frontier</a>
+        <a href="dcf.html" class="text-white/80 hover:text-white">DCF</a>
+        <a href="about.html" class="text-white/80 hover:text-white">About</a>
+        <a href="faq.html" class="text-white/80 hover:text-white">FAQ</a>
+        <button id="theme-toggle" class="ml-4 p-2 rounded bg-white/10 hover:bg-white/20 transition-colors"><span id="theme-icon">🌙</span></button>
       </nav>
     </div>
   </header>
@@ -36,23 +40,23 @@
 
     <!-- GPT Cards -->
     <div class="grid grid-cols-2 sm:grid-cols-4 gap-6">
-      <a href="https://chatgpt.com/g/g-683647bb3a7c8191bcf01d080e98832a-etf-comparator" class="flex flex-col items-center p-4 bg-white rounded-lg shadow-sm hover:shadow-md">
+      <a href="https://chatgpt.com/g/g-683647bb3a7c8191bcf01d080e98832a-etf-comparator" class="flex flex-col items-center p-4 bg-white dark:bg-gray-800 rounded-lg shadow-sm transition transform hover:-translate-y-1 hover:shadow-lg">
         <img src="icon.png" alt="ETF Comparator" class="w-12 h-12 mb-2"/>
         <span class="text-sm font-medium">ETF Comparator</span>
       </a>
-      <a href="https://chatgpt.com/g/g-6834fda7d5dc8191bbec42beb517cdbe-financial-sentiment-analyst" class="flex flex-col items-center p-4 bg-white rounded-lg shadow-sm hover:shadow-md">
+      <a href="https://chatgpt.com/g/g-6834fda7d5dc8191bbec42beb517cdbe-financial-sentiment-analyst" class="flex flex-col items-center p-4 bg-white dark:bg-gray-800 rounded-lg shadow-sm transition transform hover:-translate-y-1 hover:shadow-lg">
         <img src="icon.png" alt="Financial Sentiment Analyst" class="w-12 h-12 mb-2"/>
         <span class="text-sm font-medium">Financial Sentiment Analyst</span>
       </a>
-      <a href="https://chatgpt.com/g/g-6834b1859e388191844227e66e16a1d9-investment-swot-strategist" class="flex flex-col items-center p-4 bg-white rounded-lg shadow-sm hover:shadow-md">
+      <a href="https://chatgpt.com/g/g-6834b1859e388191844227e66e16a1d9-investment-swot-strategist" class="flex flex-col items-center p-4 bg-white dark:bg-gray-800 rounded-lg shadow-sm transition transform hover:-translate-y-1 hover:shadow-lg">
         <img src="icon.png" alt="Investment SWOT Strategist" class="w-12 h-12 mb-2"/>
         <span class="text-sm font-medium">Investment SWOT Strategist</span>
       </a>
-      <a href="https://chatgpt.com/g/g-68195aedf75c81918d5d82526506e8e3-portfolio-optimizer-pro-ai-investment-assistant" class="flex flex-col items-center p-4 bg-white rounded-lg shadow-sm hover:shadow-md">
+      <a href="https://chatgpt.com/g/g-68195aedf75c81918d5d82526506e8e3-portfolio-optimizer-pro-ai-investment-assistant" class="flex flex-col items-center p-4 bg-white dark:bg-gray-800 rounded-lg shadow-sm transition transform hover:-translate-y-1 hover:shadow-lg">
         <img src="icon.png" alt="Portfolio Optimizer Pro" class="w-12 h-12 mb-2"/>
         <span class="text-sm font-medium">Portfolio Optimizer Pro</span>
       </a>
-      <a href="https://chatgpt.com/g/g-6838b98d97348191aa3c0428aa814ad2-portfolio-analysis-assistant" class="flex flex-col items-center p-4 bg-white rounded-lg shadow-sm hover:shadow-md">
+      <a href="https://chatgpt.com/g/g-6838b98d97348191aa3c0428aa814ad2-portfolio-analysis-assistant" class="flex flex-col items-center p-4 bg-white dark:bg-gray-800 rounded-lg shadow-sm transition transform hover:-translate-y-1 hover:shadow-lg">
         <img src="icon.png" alt="Portfolio Analysis Assistant" class="w-12 h-12 mb-2"/>
         <span class="text-sm font-medium">Portfolio Analysis Assistant</span>
       </a>
@@ -61,11 +65,13 @@
   </main>
 
   <!-- Footer -->
-  <footer class="mt-auto w-full bg-white p-4 text-center text-sm text-gray-600">
+  <footer class="mt-auto w-full bg-white dark:bg-gray-800 p-4 text-center text-sm text-gray-600 dark:text-gray-400">
     <p>Get more stock data here — <a href="https://stockanalysis.com/pro/?ref=daniel" target="_blank" class="text-blue-600 hover:underline">Stock Analysis Pro</a></p>
     <p class="mt-2 font-semibold">Disclosure:</p>
     <p>This is not investment advice; educational purpose only. I may earn a commission if you subscribe—at no extra cost to you.</p>
   </footer>
+
+  <script src="theme.js"></script>
 
 </body>
 </html>

--- a/prompt.html
+++ b/prompt.html
@@ -4,22 +4,26 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>How-To Guide - AI Investment Finance</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <script>tailwind.config = { darkMode: 'class' }</script>
   <script src="https://cdn.tailwindcss.com"></script>
+  <style>body{font-family:'Inter',sans-serif}</style>
 </head>
-<body class="bg-gray-50 text-gray-800 min-h-screen flex flex-col items-center">
+<body class="bg-gray-50 text-gray-800 dark:bg-gray-900 dark:text-gray-100 min-h-screen flex flex-col items-center">
 
   <!-- Header -->
-  <header class="fixed top-0 w-full bg-white shadow-sm z-10">
+  <header class="fixed top-0 w-full bg-gradient-to-r from-blue-500 to-indigo-600 dark:from-gray-800 dark:to-gray-900 text-white shadow-md z-10">
     <div class="max-w-4xl mx-auto flex items-center justify-between p-4">
       <div class="text-xl font-semibold">AI-Invest</div>
-      <nav class="space-x-4">
-         <a href="index.html" class="text-gray-700 hover:text-blue-600">Home</a>
-        <a href="features.html" class="text-gray-700 hover:text-blue-600">Features</a>
-        <a href="prompt.html" class="text-gray-700 hover:text-blue-600">How-To</a>
-        <a href="efficient-frontier.html" class="text-blue-600 font-medium">Efficient Frontier</a>
-        <a href="dcf.html" class="text-blue-600 font-medium">DCF</a>
-        <a href="about.html" class="text-blue-600 font-medium">About</a>
-        <a href="faq.html" class="text-blue-600 font-medium">FAQ</a>
+      <nav class="flex items-center space-x-4">
+         <a href="index.html" class="text-white/80 hover:text-white">Home</a>
+        <a href="features.html" class="text-white/80 hover:text-white">Features</a>
+        <a href="prompt.html" class="text-white/80 hover:text-white">How-To</a>
+        <a href="efficient-frontier.html" class="text-white/80 hover:text-white">Efficient Frontier</a>
+        <a href="dcf.html" class="text-white/80 hover:text-white">DCF</a>
+        <a href="about.html" class="text-white/80 hover:text-white">About</a>
+        <a href="faq.html" class="text-white/80 hover:text-white">FAQ</a>
+        <button id="theme-toggle" class="ml-4 p-2 rounded bg-white/10 hover:bg-white/20 transition-colors"><span id="theme-icon">🌙</span></button>
       </nav>
     </div>
   </header>
@@ -30,7 +34,7 @@
     <!-- Deep Research Capabilities -->
     <section>
       <h2 class="text-2xl font-semibold mb-4">🧠 Run Deep Research with AI Tools</h2>
-      <div class="bg-white p-6 rounded-lg shadow-sm space-y-4">
+      <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-sm space-y-4">
         <img src="Screenshot 2025-05-30 221227.png" alt="Deep Research Tools UI" class="rounded border shadow w-64 mx-auto">
         <p class="text-sm text-gray-700 text-center">The tools available within ChatGPT for investment workflows now include:</p>
         <ul class="list-disc list-inside text-sm space-y-1">
@@ -44,7 +48,7 @@
     </section>
 
     <!-- Choosing the Right Model -->
-    <section class="bg-white p-6 rounded-lg shadow-sm">
+    <section class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-sm">
       <h2 class="text-xl font-semibold mb-4">Choosing the Right GPT Model for Finance</h2>
       <div class="space-y-6">
         <div>
@@ -82,7 +86,7 @@
           <h3 class="text-lg font-semibold mb-2">✅ Summary Table</h3>
           <div class="overflow-x-auto">
             <table class="min-w-full text-sm text-left border border-gray-300">
-              <thead class="bg-gray-100">
+              <thead class="bg-gray-100 dark:bg-gray-700">
                 <tr>
                   <th class="border px-3 py-2">Task</th>
                   <th class="border px-3 py-2">Best Model</th>
@@ -95,7 +99,7 @@
                   <td class="border px-3 py-2">GPT-4 Turbo</td>
                   <td class="border px-3 py-2">Handles complex financial documents efficiently</td>
                 </tr>
-                <tr class="bg-gray-50">
+                <tr class="bg-gray-50 dark:bg-gray-900">
                   <td class="border px-3 py-2">Sentiment analysis</td>
                   <td class="border px-3 py-2">GPT-4 / Turbo</td>
                   <td class="border px-3 py-2">Captures nuance, sarcasm, and context better than GPT-3.5</td>
@@ -113,7 +117,7 @@
     </section>
 
     <!-- Prompting Techniques -->
-    <section class="bg-white p-6 rounded-lg shadow-sm">
+    <section class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-sm">
       <h2 class="text-xl font-semibold mb-2">Prompting Techniques</h2>
       <div class="space-y-6">
         <div>
@@ -166,7 +170,7 @@
     </section>
 
     <!-- Footer -->
-    <footer class="bg-white p-4 rounded-lg shadow-inner text-sm text-gray-600">
+    <footer class="bg-white dark:bg-gray-800 p-4 rounded-lg shadow-inner text-sm text-gray-600 dark:text-gray-400">
       <p class="font-semibold">Sources:</p>
       <ul class="list-inside list-disc ml-4 mb-4">
         <li><a href="https://medium.com/prompt-engine/how-i-use-chatgpt-for-investing-8010dab737fa" target="_blank" class="text-blue-600 hover:underline">How I Use ChatGPT for Investing</a></li>
@@ -177,6 +181,7 @@
       <p>This is not investment advice; educational purpose only. I may earn a commission if you subscribe—at no extra cost to you.</p>
     </footer>
   </main>
+  <script src="theme.js"></script>
 </body>
 </html>
 

--- a/theme.js
+++ b/theme.js
@@ -1,0 +1,21 @@
+// Toggle dark mode and store preference
+document.addEventListener('DOMContentLoaded', () => {
+  const toggle = document.getElementById('theme-toggle');
+  const icon = document.getElementById('theme-icon');
+  const html = document.documentElement;
+
+  const setIcon = () => {
+    icon.textContent = html.classList.contains('dark') ? '☀️' : '🌙';
+  };
+
+  if (localStorage.theme === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+    html.classList.add('dark');
+  }
+  setIcon();
+
+  toggle.addEventListener('click', () => {
+    html.classList.toggle('dark');
+    localStorage.theme = html.classList.contains('dark') ? 'dark' : 'light';
+    setIcon();
+  });
+});


### PR DESCRIPTION
## Summary
- refresh all pages with a gradient header, Inter font, and responsive card hover effects
- add a reusable theme.js script to toggle dark mode and remember user preference
- update content sections and footers to support dark color scheme

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4c96443108326891afbdbcf6791ed