### PR TITLE
Fix GH Pages workflow and add placeholder index.html

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,24 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm install
+      - run: npm run build
+      - run: npm run export
+      - uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./web/docs

--- a/web/docs/index.html
+++ b/web/docs/index.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html>
+  <head><meta charset="utf-8"><title>InvestGPT</title></head>
+  <body>
+    <h1>InvestGPT Pages is live 🎉</h1>
+    <p>Backend URL will be added later.</p>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow that installs dependencies with `npm install`, builds, exports, and publishes `./web/docs` to `gh-pages`.
- Provide placeholder `web/docs/index.html` so GitHub Pages has content.

## Testing
- `npm run build` *(fails: Could not read package.json)*
- `npm run export` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68bb8f3c618c8326867d6427d6cdc9c4